### PR TITLE
added NoFocusOnAppearing to rotation and timeline window

### DIFF
--- a/ActionTimeline/Windows/RotationWindow.cs
+++ b/ActionTimeline/Windows/RotationWindow.cs
@@ -18,7 +18,8 @@ namespace ActionTimeline.Windows
                                             | ImGuiWindowFlags.NoCollapse
                                             | ImGuiWindowFlags.NoTitleBar
                                             | ImGuiWindowFlags.NoNav
-                                            | ImGuiWindowFlags.NoScrollWithMouse;
+                                            | ImGuiWindowFlags.NoScrollWithMouse
+                                            | ImGuiWindowFlags.NoFocusOnAppearing;
 
         public RotationWindow(string name) : base(name)
         {

--- a/ActionTimeline/Windows/TimelineWindow.cs
+++ b/ActionTimeline/Windows/TimelineWindow.cs
@@ -19,7 +19,8 @@ namespace ActionTimeline.Windows
                                             | ImGuiWindowFlags.NoCollapse
                                             | ImGuiWindowFlags.NoTitleBar
                                             | ImGuiWindowFlags.NoNav
-                                            | ImGuiWindowFlags.NoScrollWithMouse;
+                                            | ImGuiWindowFlags.NoScrollWithMouse
+                                            | ImGuiWindowFlags.NoFocusOnAppearing;
 
         public TimelineWindow(string name) : base(name)
         {


### PR DESCRIPTION
Currently the timeline and rotation windows steal focus from other windows when they appear. This is particularly apparent when they are set to appear when entering combat. In this case they would steal focus from other plugin windows like chat plugins.